### PR TITLE
#5 multivariate newton raphson

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ $ make CXX=g++-4.9
 ## Configuration
 
 See the [example config file](configs/example.json) for an overview of the options.
+
+## Dependencies
+
+**LAPACK**: On Ubuntu:
+
+``` shell
+$ sudo apt install liblapack-dev
+```

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 
 dependencies:
   override:
+    - sudo apt-get install -y liblapacke-dev
     - g++ --version
     - make CXX=g++-4.9 tests
 test:

--- a/include/optimisation.hpp
+++ b/include/optimisation.hpp
@@ -6,20 +6,55 @@
 #ifndef OPTIM_H
 #define OPTIM_H
 #include <functional>
+#include <lapacke.h>
 
-/*
-  Newton-Raphson method for root finding.
-  Determines x such that f(x) = 0
-  Requires f(x) and f'(x) for computation.
-  Convergence criteria is the abs error for each dimension of f(x)
-  Returns 0 on success. -1 if max_iter reached
- */
 namespace optimisation {
+    const int SUCCESS = 0b0;
+    const int MAX_ITERATIONS_ERR = 0b1;
+    const int LAPACK_ERR = 0b10;
+
+    /*
+      Newton-Raphson method for root finding.
+      Determines x such that f(x) = 0
+      Requires f(x) and f'(x) for computation.
+      Convergence criteria is the abs error for each dimension of f(x)
+      Returns SUCCESS on success. MAX_ITERATIONS_ERR if max_iter reached
+    */
     int newton_raphson_1( double *x_root,
                           const std::function<double(const double) > f,
                           const std::function<double(const double) > fdash,
                           const double x0,
                           const double eps=1e-7,
                           const size_t max_iter=1000 );
+
+    /*
+      Newton-Raphson method finds the root F(x)=0 where F : N -> N
+      Jacobian of F is denoted J where J : N -> NxN
+      Newton iteration xn = x - inv(J(x))/F(x)
+      This function avoids inverse by solving the linear system:
+          J(x)(xn - x) = -F(x)
+      Params:
+        x_root is size N
+         x_tmp is size N
+       jac_out is size NxN
+          ipiv is size N
+            x0 is size N
+
+      NB: error is calculated as the 2-norm of the residual vector (xnext-xprev)
+      Returns SUCCESS or LAPACK_ERR (check lapack_err_code) or MAX_ITERATIONS_ERR
+
+      lapack_err_code - 0=ok -i=ith val is illegal i=i is exactly 0 (singular)
+    */
+    int newton_raphson_noinv(
+        double *x_root,
+        double *x_tmp,
+        double *jac_out,
+        lapack_int *ipiv,
+        int *lapack_err_code,
+        const std::function<void(double*,const double* )> f,
+        const std::function<void(double*,const double* )> jacobian,
+        const double *x0, const lapack_int dim,
+        const double eps=1e-7,
+        const size_t max_iter=1000 );
 }
 #endif

--- a/include/optimisation.hpp
+++ b/include/optimisation.hpp
@@ -15,15 +15,11 @@
   Returns 0 on success. -1 if max_iter reached
  */
 namespace optimisation {
-    int newton_raphson( double *x_root,
-                         double *x_f,
-                         double *x_fdash,
-                         double *x_tmp,
-                         const std::function<void(double *, const double *) > f,
-                         const std::function<void(double *, const double *) > fdash,
-                         const double *x0,
-                         const size_t dim,
-                         const double eps=1e-7,
-                         const size_t max_iter=1000 );
+    int newton_raphson_1( double *x_root,
+                          const std::function<double(const double) > f,
+                          const std::function<double(const double) > fdash,
+                          const double x0,
+                          const double eps=1e-7,
+                          const size_t max_iter=1000 );
 }
 #endif

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -3,8 +3,8 @@
 // Oliver W. Laslett (2016)
 // O.Laslett@soton.ac.uk
 #include "../include/optimisation.hpp"
-#include "../include/easylogging++.h"
 #include <cmath>
+#include <cblas.h>
 
 int optimisation::newton_raphson_1(
     double *x_root,
@@ -27,5 +27,74 @@ int optimisation::newton_raphson_1(
         err = std::abs( x2 - x1 );
     }
     *x_root=x2;
-    return iter==-1 ? iter : 0;
+    return iter==-1 ? optimisation::MAX_ITERATIONS_ERR: optimisation::SUCCESS;
+}
+
+int optimisation::newton_raphson_noinv (
+    double *x_root,
+    double *x_tmp,
+    double *jac_out,
+    lapack_int *ipiv,
+    int *lapack_err_code,
+    const std::function<void(double*,const double* )> f,
+    const std::function<void(double*,const double*)> jacobian,
+    const double *x0,
+    const lapack_int dim,
+    const double eps,
+    const size_t max_iter )
+{
+    // Initialise the error
+    double err=2*eps;
+
+    // Copy in the initial condition
+    for( int i=0; i<dim; i++ )
+        x_root[i] = x0[i];
+
+    // Repeat until convergence
+    int iter = max_iter;
+    while( ( err > eps ) && ( iter --> 0 ) )
+    {
+        // Get the previous state
+        for( int i=0; i<dim; i++ )
+            x_tmp[i] = x_root[i];
+
+        f( x_root, x_tmp );
+        jacobian( jac_out, x_tmp );
+
+        // Arrange into form J(xprev)(xnext-xprev)=-F(xprev)
+        for( int i=0; i<dim; i++ )
+            x_root[i] *= -1;
+
+        /*
+          Solve for the next state
+          Use LAPACKE_dgesv to solve Ax=B for x
+          lapack_int dgesv( matrix_order, N, NRHS, A, LDA, IPIV, B, LDB )
+          order - LAPACK_ROW_MAJOR or LAPACK_COL_MAJOR
+              N - number of equations
+           NRHS - number of right hand sides (columns of B)
+              A - NxN left matrix
+            LDA - leading dimension of A (i.e length of first dimension)
+           IPIV - [out] the pivot indices
+              B - [in] NxNHRS input B [out] the NxNHRS solution for x
+            LDB - leading dimension of array B
+
+          suffix _work indicates user will alloc required memory for the routine
+          but in this case no additional allocations are required
+          Returns error flag - 0=ok -i=ith val is illegal i=i is exactly 0 (singular)
+        */
+        *lapack_err_code = LAPACKE_dgesv_work(
+            LAPACK_ROW_MAJOR, dim, 1, jac_out, dim, ipiv, x_root, 1 );
+        if( *lapack_err_code!=0 )
+            return optimisation::LAPACK_ERR;
+
+
+        // The returned value is in x_root and is (xnext-xprev)
+        // The error is the 2-norm of (xnext-xprev)
+        err = cblas_dnrm2( dim, x_root, 1 );
+
+        // Add xprev to solution to get the actual result
+        for( int i=0; i<dim; i++ )
+            x_root[i] += x_tmp[i];
+    }
+    return iter==-1 ? optimisation::MAX_ITERATIONS_ERR : optimisation::SUCCESS;
 }

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -6,39 +6,26 @@
 #include "../include/easylogging++.h"
 #include <cmath>
 
-int optimisation::newton_raphson(
+int optimisation::newton_raphson_1(
     double *x_root,
-    double *x_f,
-    double *x_fdash,
-    double *x_tmp,
-    const std::function<void(double *, const double * )> f,
-    const std::function<void(double *, const double * )> fdash,
-    const double *x0,
-    const size_t dim,
+    const std::function<double(const double )> f,
+    const std::function<double(const double )> fdash,
+    const double x0,
     const double eps,
     const size_t max_iter )
 {
-    // Copy in the initial state
-    for( unsigned int i=0; i<dim; i++ )
-        x_root[i] = x0[i] + 2*eps;
-
     // Initialise the error (ensure at least one iteration)
     double err = 2*eps;
+    double x1, x2=x0;
 
     // Repeat until convergence
     int iter=max_iter;
     while( ( err > eps ) && ( iter --> 0 ) )
     {
-        for( unsigned int i=0; i<dim; i++ )
-            x_tmp[i] = x_root[i];
-        f( x_f, x_tmp );
-        fdash( x_fdash, x_tmp );
-        err = 0;
-        for( unsigned int i=0; i<dim; i++ )
-        {
-            x_root[i] = x_tmp[i] - x_f[i]/x_fdash[i];
-            err += std::abs( x_root[i] - x_tmp[i] );
-        }
+        x1 = x2;
+        x2 = x1 - f( x1 )/fdash( x1 );
+        err = std::abs( x2 - x1 );
     }
+    *x_root=x2;
     return iter==-1 ? iter : 0;
 }

--- a/makefile
+++ b/makefile
@@ -24,6 +24,8 @@ else
 	CXXFLAGS=--std=c++11 -W -Wall -pedantic -pthread -O3 -g -fopenmp -DVERSION=\"$(GIT_VERSION)\"
 endif
 
+LDFLAGS=-llapacke -lblas
+
 SOURCES=$(wildcard $(LIB_PATH)/*.cpp)
 OBJ_FILES=$(addprefix $(OBJ_PATH)/,$(notdir $(SOURCES:.cpp=.o)))
 
@@ -32,18 +34,19 @@ default: main
 
 main: src/main.cpp $(OBJ_FILES)
 	$(CXX) $(CXXFLAGS) $< \
-	$(OBJ_FILES) \
+	$(OBJ_FILES) $(LDFLAGS) \
 	-o $@
 
 # Build the individual object files
 $(OBJ_PATH)/%.o: $(LIB_PATH)/%.cpp
 	$(CXX) 	$(CXXFLAGS) -c \
 	-o $@ $<
+	$(LDFLAGS)
 
 # The tests are run using googletest
 tests: test/tests.cpp $(OBJ_FILES) $(GTEST_HEADERS) gtest_main.a
 	$(CXX) $(GTEST_FLAGS) $(CXXFLAGS) $< gtest_main.a \
-	$(OBJ_FILES) \
+	$(OBJ_FILES) $(LDFLAGS) \
 	-o $@
 
 # Builds the gtest testing suite

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -10,6 +10,7 @@
 #include "../include/optimisation.hpp"
 #include <cmath>
 #include <random>
+#include <lapacke.h>
 
 INITIALIZE_EASYLOGGINGPP
 
@@ -282,7 +283,7 @@ TEST( newton_raphson, 1d_function )
     int res = optimisation::newton_raphson_1(
         &x_root, f, fdash, x0, eps, max_iter );
     ASSERT_LE( std::abs( x_root - 3.2 ), eps );
-    ASSERT_EQ( 0, res );
+    ASSERT_EQ( optimisation::SUCCESS, res );
 }
 
 TEST( newton_raphson, 1d_funtion_max_iter )
@@ -298,5 +299,83 @@ TEST( newton_raphson, 1d_funtion_max_iter )
     int res = optimisation::newton_raphson_1(
         &x_root, f, fdash, x0, eps, max_iter );
 
-    ASSERT_EQ( -1, res );
+    ASSERT_EQ( optimisation::MAX_ITERATIONS_ERR, res );
+}
+
+TEST( newton_raphson_noinv, 2d_function_2_sols )
+{
+    double x_root[2], x_tmp[2], jac_out[4], x0[2], eps=1e-8;
+    lapack_int dim=2, ipiv[2];
+    size_t max_iter=100;
+    int lapack_err;
+
+    /*
+      F = [ -(x-2)^2 - 2xy,
+            -y(x+1) - 4y ]
+      F(x,y)==0 has 2 solutions:
+        x,y=-5,4.9    x,y=2,0
+    */
+    auto f = []( double*out,const double*in )->void
+    {
+        out[0] = -( in[0]-2 )*( in[0]-2 ) - 2*in[0]*in[1];
+        out[1] = -in[1]*( in[0]+1 ) - 4*in[1];
+    };
+    auto jac = []( double*out,const double*in )->void
+    {
+        out[0] = -2*in[0] - 2*in[1] + 4;
+        out[1] = -2*in[0];
+        out[2] = -in[1];
+        out[3] = -in[0]-5;
+    };
+
+    // Find the first solution
+    x0[0] = x0[1] = -5.2;
+    auto flag = optimisation::newton_raphson_noinv(
+        x_root, x_tmp, jac_out, ipiv, &lapack_err,
+        f, jac, x0, dim, eps, max_iter );
+    ASSERT_EQ( optimisation::SUCCESS, flag );
+    ASSERT_LE( std::abs( x_root[0] + 5 ), eps );
+    ASSERT_LE( std::abs( x_root[1] - 4.9 ), eps );
+
+    // Find the second solution
+    x0[0] = x0[1] = 1.0;
+    flag = optimisation::newton_raphson_noinv(
+        x_root, x_tmp, jac_out, ipiv, &lapack_err,
+        f, jac, x0, dim, eps, max_iter );
+    ASSERT_EQ( optimisation::SUCCESS, flag );
+    ASSERT_LE( std::abs( x_root[0] - 2 ), eps );
+    ASSERT_LE( std::abs( x_root[1] ), eps );
+}
+
+TEST( newton_raphson_noinv, 2d_function_singular )
+{
+    double x_root[2], x_tmp[2], jac_out[4], x0[2], eps=1e-8;
+    lapack_int dim=2, ipiv[2];
+    size_t max_iter=100;
+    int lapack_err;
+
+    /*
+      This function has infinite solutions which will create
+      a singular matrix in the LU factorisation in lapack routine
+    */
+    auto f = []( double*out,const double*in )->void
+    {
+        out[0] = -( in[0]-2 )*( in[0]-2 ) - 2*in[0]*in[1];
+        out[1] = out[0]*5.9;
+    };
+    auto jac = []( double*out,const double*in )->void
+    {
+        out[0] = -2*in[0] - 2*in[1] + 4;
+        out[1] = -2*in[0];
+        out[2] = out[0]*5.9;
+        out[3] = out[1]*5.9;
+    };
+
+    // Find the first solution
+    x0[0] = x0[1] = -5.2;
+    auto flag = optimisation::newton_raphson_noinv(
+        x_root, x_tmp, jac_out, ipiv, &lapack_err,
+        f, jac, x0, dim, eps, max_iter );
+    ASSERT_EQ( optimisation::LAPACK_ERR, flag );
+    ASSERT_GE( lapack_err, 0 );
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -271,29 +271,32 @@ TEST( moma_config, validate_compute_options )
 
 TEST( newton_raphson, 1d_function )
 {
-    auto f = []( double *out, const double *in )->void
-        { out[0] = -(in[0]-3.2)*(in[0]-3.2); };
-    auto fdash = []( double *out, const double *in )->void
-        { out[0] = -2*(in[0]-3.2); };
-    double x0[1] = {0.0}, eps=1e-6, x_root[1], x_f[1], x_fdash[1], x_tmp[1];
-    const size_t dim=1, max_iter=100;
+    auto f = [](const double x)->double
+        { return -(x-3.2)*(x-3.2); };
+    auto fdash = [](const double x)->double
+        { return -2*(x-3.2); };
 
-    int res = optimisation::newton_raphson( x_root, x_f, x_fdash, x_tmp, f,
-                                            fdash, x0, dim, eps, max_iter );
-    ASSERT_LE( std::abs( x_root[0] - 3.2 ), eps );
+    double x0=0.0, eps=1e-6, x_root;
+    const size_t max_iter=100;
+
+    int res = optimisation::newton_raphson_1(
+        &x_root, f, fdash, x0, eps, max_iter );
+    ASSERT_LE( std::abs( x_root - 3.2 ), eps );
     ASSERT_EQ( 0, res );
 }
 
 TEST( newton_raphson, 1d_funtion_max_iter )
 {
-    auto f = []( double *out, const double *in )->void
-        { out[0] = -(in[0]-3.2)*(in[0]-3.2); };
-    auto fdash = []( double *out, const double *in )->void
-        { out[0] = -2*(in[0]-3.2); };
-    double x0[1] = {0.0}, eps=1e-6, x_root[1], x_f[1], x_fdash[1], x_tmp[1];
-    const size_t dim=1, max_iter=2;
+    auto f = [](const double x)->double
+        { return -(x-3.2)*(x-3.2); };
+    auto fdash = [](const double x)->double
+        { return -2*(x-3.2); };
 
-    int res = optimisation::newton_raphson( x_root, x_f, x_fdash, x_tmp, f,
-                                            fdash, x0, dim, eps, max_iter );
+    double x0=0.0, eps=1e-6, x_root;
+    const size_t max_iter=2;
+
+    int res = optimisation::newton_raphson_1(
+        &x_root, f, fdash, x0, eps, max_iter );
+
     ASSERT_EQ( -1, res );
 }


### PR DESCRIPTION
Moved the current Newton-Raphson to scalar only

Wrote a multivariate Newton method. Avoids inverting the Jacobian by calling LAPACK solvers.

Addresses #5 