### PR TITLE
Improve dom

### DIFF
--- a/include/dom.hpp
+++ b/include/dom.hpp
@@ -18,5 +18,7 @@ namespace dom
         const double k, const double v, const double T, const double ms,
         const double alpha, const double t, const double *state_probabilities,
         const std::function<double(double)> applied_field );
+
+    double single_transition_energy(double K, double V, double h);
 }
 #endif

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -117,6 +117,13 @@ namespace simulation
     double energy_loss(
         const struct results&, const double ms, const double hk );
 
+    // Compute the energy loss for a particle from the probability flow
+    double energy_loss(
+        const std::unique_ptr<double[]> &transition_energy,
+        const std::unique_ptr<double[]> &probability_flow,
+        const std::unique_ptr<double[]> &time,
+        const size_t N );
+
     // Sets all of the arrays in the results struct to zero
     void zero_results( struct results& );
 

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -122,7 +122,15 @@ namespace simulation
         const std::unique_ptr<double[]> &transition_energy,
         const std::unique_ptr<double[]> &probability_flow,
         const std::unique_ptr<double[]> &time,
+        const double volume,
         const size_t N );
+
+    // Computes the energy loss over just one step of the integrator
+    // Used for summing energy loss step-by-step without storing intermediate results
+    double one_step_energy_loss(
+        const double te1, const  double te2, const double pflow1, const double pflow2,
+        const double t1, const double t2, const double volume
+        );
 
     // Sets all of the arrays in the results struct to zero
     void zero_results( struct results& );

--- a/include/trap.hpp
+++ b/include/trap.hpp
@@ -13,5 +13,10 @@ namespace trap
       The grid can be non-uniform of length N.
      */
     double trapezoidal( double *x, double *y, size_t N);
+
+    /*
+      Just a single term of the trapezoidal summation
+    */
+    double one_trapezoid( double x1, double x2, double fx1, double fx2 );
 }
 #endif

--- a/lib/dom.cpp
+++ b/lib/dom.cpp
@@ -3,6 +3,19 @@
 #include "../include/stochastic_processes.hpp"
 #include <cmath>
 
+/// Compute the energy dissipated during one transition of the particle
+/**
+ * @param[in] K anisotropy constant of the particle
+ * @param[in] V volume of the particle
+ * @param[in] h applied field on the particle, reduced by the anisotropy
+ *              field \f$H_k=\frac{2K}{\mu_0M_s}\f$
+ * @returns the energy dissipated in one transition
+ */
+double dom::single_transition_energy(double K, double V, double h)
+{
+    return 4*K*V*h;
+}
+
 /// Compute the 2x2 transition matrix for a single particle
 /**
  * Assumes uniaxial anisotropy and an applied field h<1

--- a/lib/simulation.cpp
+++ b/lib/simulation.cpp
@@ -306,6 +306,7 @@ struct simulation::results simulation::dom_ensemble_dynamics(
 
     // Variables needed in the loop
     double t=0;
+    double max_dt = end_time / 1000.0; // never step more than 1000th of the simulation time
     double dt = 0.01*time_step;
     unsigned int step=0;
     double eps=time_step; // tolerance of the rk45 integrator
@@ -323,6 +324,9 @@ struct simulation::results simulation::dom_ensemble_dynamics(
             integrator::rk45( next_state, tmpstate, k1, k2, k3, k4, k5, k6,
                               &dt, &t, last_state, master_equation, n_dims,
                               eps );
+
+            // dt should never be greater than 1/1000 of the simulation time
+            dt = dt>max_dt? max_dt : dt;
 
         } // end integration stepping loop
         /*

--- a/lib/simulation.cpp
+++ b/lib/simulation.cpp
@@ -19,6 +19,7 @@ double simulation::energy_loss(
     double *mult = new double[N];
     for( unsigned int i; i<N; i++ )
         mult[i] = transition_energy[i] * probability_flow[i];
+    delete[] mult;
     return trap::trapezoidal( mult, time.get(), N );
 }
 

--- a/lib/trap.cpp
+++ b/lib/trap.cpp
@@ -13,3 +13,8 @@ double trap::trapezoidal( double *x, double *y, size_t N )
     sum /= 2.0;
     return sum;
 }
+
+double trap::one_trapezoid( double x1, double x2, double fx1, double fx2 )
+{
+    return 0.5 * ( x2 - x1 ) * ( fx2 + fx1 );
+}


### PR DESCRIPTION
 - Limit the maximum time step of the adaptive RK4 solver
 - Compute the power dissipation from the probability flow at every time step rather than using the hysteresis loop (this is more stable for rapidly varying fields)
 - 